### PR TITLE
feat: added schedule for cards update

### DIFF
--- a/.github/workflows/update-cards.yaml
+++ b/.github/workflows/update-cards.yaml
@@ -1,0 +1,29 @@
+name: GRS card generation
+on:
+  schedule:
+    #        ┌───────────── minute (0 - 59)
+    #        │ ┌───────────── hour (0 - 23)
+    #        │ │  ┌───────────── day of the month (1 - 31)
+    #        │ │  │  ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │ │  │  │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │ │  │  │ │
+    #        │ │  │  │ │
+    #        │ │  │  │ │
+    #        * *  *  * *
+    - cron: "0 0 */1 * *"
+
+jobs:
+  ceateGRSCards:
+    name: Create and Store GRS cards
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run top issues action
+        uses: claytonsilva/github-readme-stats@master
+        env:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          save_path: ""
+          stats_card_query: ?username=claytonsilva
+          lang_card_query: ?username=claytonsilva
+          repo_card_query: ?username=claytonsilva&repo=github-readme-stats
+          wakatime_card_query: ?username=claytonsilva


### PR DESCRIPTION
Adicionado job de update dos cards de stats para evitar o problema do card não carregar inicialmente.

O workaround é baseado[ nessa issue](https://github.com/anuraghazra/github-readme-stats/issues/2179)