### PR TITLE
feat(readme): added project to pinneds

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ em [inglês](https://github.com/claytonsilva/claytonsilva/blob/main/RESUME_EN-US
 <a href="https://github.com/catdevsecops/home-automated-infrastructure">
   <img align="center" src="https://github-readme-stats-beta-ashy.vercel.app/api/pin/?username=catdevsecops&repo=home-automated-infrastructure&show_icons=true&theme=transparent" />
 </a>
+<a href="https://github.com/catdevsecops/solarz-homeassistant-api-wrapper">
+  <img align="center" src="https://github-readme-stats-beta-ashy.vercel.app/api/pin/?username=catdevsecops&repo=solarz-homeassistant-api-wrapper&show_icons=true&theme=transparent" />
+</a>
 
 ## Certificações
 


### PR DESCRIPTION
This pull request adds a new project showcase to the `README.md` file. The main change is the inclusion of a GitHub repository badge for the `solarz-homeassistant-api-wrapper` project, making it more visible in the profile.

**Project showcase update:**

* Added a new badge and link for the `solarz-homeassistant-api-wrapper` repository to the project section in `README.md`.